### PR TITLE
fixtypo: self -> Self

### DIFF
--- a/posts/common-rust-lifetime-misconceptions.md
+++ b/posts/common-rust-lifetime-misconceptions.md
@@ -922,7 +922,7 @@ struct Struct;
 
 impl Struct {
     // downgrades mut self to shared self
-    fn some_method(&mut self) -> &self;
+    fn some_method(&mut self) -> &Self;
 
     // downgrades mut self to shared T
     fn other_method(&mut self) -> &T;


### PR DESCRIPTION
`self` is not a type…? I think it’s a typo.