### PR TITLE
Update tour-of-rusts-standard-library-traits.md fix: can _be_ dereferenced

### DIFF
--- a/posts/tour-of-rusts-standard-library-traits.md
+++ b/posts/tour-of-rusts-standard-library-traits.md
@@ -2836,7 +2836,7 @@ trait DerefMut: Deref {
 }
 ```
 
-`Deref<Target = T>` types can dereferenced to `T` types using the dereference operator `*`. This has obvious use-cases for smart pointer types like `Box` and `Rc`. However, we rarely see the dereference operator explicitly used in Rust code, and that's because of a Rust feature called _deref coercion_.
+`Deref<Target = T>` types can be dereferenced to `T` types using the dereference operator `*`. This has obvious use-cases for smart pointer types like `Box` and `Rc`. However, we rarely see the dereference operator explicitly used in Rust code, and that's because of a Rust feature called _deref coercion_.
 
 Rust automatically dereferences types when they're being passed as function arguments, returned from a function, or used as part of a method call. This is the reason why we can pass `&String` and `&Vec<T>` to functions expecting `&str` and `&[T]` because `String` impls `Deref<Target = str>` and `Vec<T>` impls `Deref<Target = [T]>`.
 


### PR DESCRIPTION
fix: can _be_ dereferenced