### PR TITLE
Minor correction in the example.

### DIFF
--- a/posts/tour-of-rusts-standard-library-traits.md
+++ b/posts/tour-of-rusts-standard-library-traits.md
@@ -866,7 +866,8 @@ impl Subtrait for SomeType {}
 // neither overriding or shadowing the other
 
 fn main() {
-    SomeType.method(); // ❌ ambiguous method call
+    let st = SomeType{};
+    SomeType.method(&st); // ❌ ambiguous method call
     // must disambiguate using fully-qualified syntax
     <SomeType as Supertrait>::method(&st); // ✅ prints "in supertrait"
     <SomeType as Subtrait>::method(&st); // ✅ prints "in subtrait"


### PR DESCRIPTION
The first example in the section **Subtraits & Supertraits** doesn't declare the variable _st_, which results in a compiler error that is unintended. A minor change to declare and initialize the variable _st_.