### PR TITLE
Result is matched against Ok and Err

### DIFF
--- a/posts/sizedness-in-rust.md
+++ b/posts/sizedness-in-rust.md
@@ -1025,8 +1025,8 @@ fn example<T>(t: &[T]) -> Vec<T> {
 fn example2() -> i32 {
     // we know this parse call will never fail
     match "123".parse::<i32>() {
-        Some(num) => num,
-        None => unreachable!(), // ! coerced to i32
+        Ok(num) => num,
+        Err(_) => unreachable!(), // ! coerced to i32
     }
 }
 


### PR DESCRIPTION
`parse` method returns value of type `Result`.