### PR TITLE
Update common-rust-lifetime-misconceptions.md

### DIFF
--- a/posts/common-rust-lifetime-misconceptions.md
+++ b/posts/common-rust-lifetime-misconceptions.md
@@ -157,7 +157,7 @@ Well yes, but a type _with_ a `'static` lifetime is different from a type _bound
 
 It's important at this point to distinguish `&'static T` from `T: 'static`.
 
-`&'static T` is an immutable reference to some `T` that can be safely held indefinitely long, including up until the end of the program. This is only possible if `T` itself is immutable and does not move _after the reference was created_. `T` does not need to be created at compile-time. It's possible to generate random dynamically allocated data at run-time and return `'static` references to it at the cost of leaking memory, e.g.
+`&'static T` is an immutable reference to some `T` that can be safely held indefinitely long, including up until the end of the program. This is only possible if `T` itself is immutable and does not move _after the reference was created_. `T` does not need to be created at compile-time. It's possible to generate random dynamically allocated data at run-time and return `'static` references to it via a memory leak, e.g.
 
 ```rust
 use rand;


### PR DESCRIPTION
It's possible to get a `'static` reference to dynamically allocated data at run-time via a memory leak, but *without* the cost of leaking memory, because:

1. We can restore the `Box` back from the reference, by using `Box::from_raw`.
3. The Box will then take care of freeing the memory (after it is dropped).

Here is an example to demonstrate this process:

```rust
use rand;

#[derive(Debug)]
struct A {
    s: String,
}

impl Drop for A {
    fn drop(&mut self) {
        println!("{:?} has been dropped!", self);
    }
}

fn leak_a() -> &'static A {
    let rand_string = rand::random::<u64>().to_string();
    let a = A {
        s: rand_string,
    };
    Box::leak(a.into())
}

fn main() {
    let a = leak_a();
    println!("a = {:?}", a);

    // restore `a` Box from the leaked reference
    let a = unsafe {
        let const_ptr = a as *const A;
        let mut_ptr = const_ptr as *mut A;
        Box::from_raw(mut_ptr)
    };
    println!("a = {:?}", a);

    // `a` will be dropped here
}
```

Output:

```
a = A { s: "14376733450705693403" }
a = A { s: "14376733450705693403" }
A { s: "14376733450705693403" } has been dropped!
```